### PR TITLE
refactor: standardize module path for easier import

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module sarama_demo_dts
+module github.com/aliyun/aliyun-dts-subscribe-demo/go
 
 go 1.18
 

--- a/go/main.go
+++ b/go/main.go
@@ -8,11 +8,12 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"sarama_demo_dts/avro"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/aliyun/aliyun-dts-subscribe-demo/go/avro"
 
 	"github.com/IBM/sarama"
 	"github.com/linkedin/goavro/v2"


### PR DESCRIPTION
- Enable direct import of avro package: `import "github.com/aliyun/aliyun-dts-subscribe-demo/go/avro"`
- Change module name from `sarama_demo_dts` to `github.com/aliyun/aliyun-dts-subscribe-demo/go`
- Update import path in main.go
